### PR TITLE
Fix macos build

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -16,8 +16,10 @@ CFLAGS += -DWIN32
 endif
 
 ifeq ($(shell uname), Darwin)
-LIBS += /opt/local/lib/libintl.a /usr/local/opt/libiconv/lib/libiconv.a -framework CoreFoundation
 INCLUDES += -I/opt/local/include
+LIBS += -liconv -framework CoreFoundation
+OPTFLAGS += -DNO_GETTEXT
+CFLAGS += -DNO_GETTEXT
 endif
 
 TARGET = git-lard

--- a/build/common.mk
+++ b/build/common.mk
@@ -4,7 +4,7 @@ XXHASHDIR = ../xxHash
 GITLIB = $(GITDIR)/libgit.a
 XDIFFLIB = $(GITDIR)/xdiff/lib.a
 
-INCLUDES = -I$(SRCPATH) -I$(SRCPATH)/..
+INCLUDES = -I$(SRCPATH) -I$(SRCPATH)/.. $(shell pkg-config --cflags openssl)
 
 LIBS := $(GITLIB) $(XDIFFLIB) -lpthread $(shell pkg-config --libs openssl zlib)
 CFLAGS := $(OPTFLAGS) -DSHA1_HEADER='<openssl/sha.h>' -I$(GITDIR)/compat/regex
@@ -16,8 +16,8 @@ CFLAGS += -DWIN32
 endif
 
 ifeq ($(shell uname), Darwin)
-INCLUDES += -I/usr/local/opt/openssl/include -I/opt/local/include
 LIBS += /opt/local/lib/libintl.a /usr/local/opt/libiconv/lib/libiconv.a -framework CoreFoundation
+INCLUDES += -I/opt/local/include
 endif
 
 TARGET = git-lard

--- a/src/Filesystem.hpp
+++ b/src/Filesystem.hpp
@@ -18,6 +18,9 @@ std::unordered_set<const char*, StringHelpers::hash, StringHelpers::equal_to> Li
 #ifdef __CYGWIN__
 #  define stat64 stat
 #endif
+#ifdef __APPLE__
+#  define stat64 stat
+#endif
 
 #ifndef S_ISREG
 #  define S_ISREG(m) ( ( (m) & S_IFMT ) == S_IFREG )


### PR DESCRIPTION
It was not possible to build git-lard on recent macOS version. Now it builds correctly assuming user has installed openssl (e.g. with brew) and properly configured `PKG_CONFIG_PATH` to point to `.pc` file of openssl package.